### PR TITLE
[Release workflow]: Add root redirect step for release workflow

### DIFF
--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -67,5 +67,5 @@ jobs:
           <meta http-equiv='refresh' content='0; url=https://fudis.funidata.fi/core/v/$VERSION/index.html' />
           </head>
           </html>" > /tmp/index.html
-          aws s3 cp /tmp/index.html s3://${{ vars.AWS_S3_BUCKET_NAME }} --cache-control max-age=5
+          aws s3 cp /tmp/index.html s3://${{ vars.AWS_S3_BUCKET_NAME }}/core --cache-control max-age=5
 

--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -60,4 +60,12 @@ jobs:
         run: npm run build:storybook
       - name: Copy docs to S3 bucket
         run: aws s3 sync storybook-static s3://${{ vars.AWS_S3_BUCKET_NAME }}/core/v/$VERSION
+      - name: Update root redirect to this version
+        run: |
+          echo "<html>
+          <head>
+          <meta http-equiv='refresh' content='0; url=https://fudis.funidata.fi/core/v/$VERSION/index.html' />
+          </head>
+          </html>" > /tmp/index.html
+          aws s3 cp /tmp/index.html s3://${{ vars.AWS_S3_BUCKET_NAME }} --cache-control max-age=5
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "0.0.2-alpha.1",
+  "version": "0.0.2-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funidata/fudis-core",
-      "version": "0.0.2-alpha.1",
+      "version": "0.0.2-alpha.2",
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "@storybook/addon-a11y": "^8.6.12",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "0.0.2-alpha.1",
+  "version": "0.0.2-alpha.2",
   "description": "Core styles and foundations for Fudis Design System",
   "files": [
     "src",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "0.0.2-alpha.1",
+  "version": "0.0.2-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funidata/fudis-core",
-      "version": "0.0.2-alpha.1",
+      "version": "0.0.2-alpha.2",
       "dependencies": {
         "prettier-plugin-jsdoc": "^1.3.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "0.0.2-alpha.1",
+  "version": "0.0.2-alpha.2",
   "scripts": {
     "build": "docker build -t fudis-core:latest ./core && docker cp $(docker create fudis-core:latest):/usr/src/app/dist ./core/dist",
     "stylelint": "stylelint '**/*.{css,scss}'",


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-497

- When navigating to `fudis.funidata.fi/core` it should redirect to the latest published Core version.
- Prereleases (such as release candidates) are not considered as latest (todo in next PR after this has been tested)