### PR TITLE
[Release Workflow]: Check latest version tag

### DIFF
--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -59,10 +59,16 @@ jobs:
         run: npm run build:storybook
       - name: Copy docs to S3 bucket
         run: aws s3 sync storybook-static s3://${{ vars.AWS_S3_BUCKET_NAME }}/core/v/$VERSION
-      - name: Log Github event object
-        if: github.event.release != null
-        run: echo '${{toJSON(github.event.release)}}'
+      - name: Get previous tag
+        run: echo "PREV_VERSION=$(git describe --tags --abbrev=0 ${{$VERSION}}^)" >> $GITHUB_ENV
+      - name: Check semver
+        id: check-semver
+        run: |
+          if [[ $VERSION -gt $PREV_VERSION && $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "set-as-latest=true" >> $GITHUB_OUTPUT
+          fi
       - name: Update root redirect to this version
+        if: steps.check-semver.outputs.set-as-latest == 'true'
         run: |
           echo "<html>
           <head>

--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -59,16 +59,19 @@ jobs:
         run: npm run build:storybook
       - name: Copy docs to S3 bucket
         run: aws s3 sync storybook-static s3://${{ vars.AWS_S3_BUCKET_NAME }}/core/v/$VERSION
-      - name: Get previous tag
-        run: echo "PREV_VERSION=$(git describe --tags --abbrev=0 ${{$VERSION}}^)" >> $GITHUB_ENV
-      - name: Check semver
-        id: check-semver
+      - name: Check for latest version
+        id: check_latest
         run: |
-          if [[ $VERSION -gt $PREV_VERSION && $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "set-as-latest=true" >> $GITHUB_OUTPUT
+          LATEST_TAG=$(curl -L \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            https://api.github.com/repos/${{ github.repository }}/releases/latest \
+            | jq -r '.tag_name')
+
+          if [[ "${LATEST_TAG}" == "${{ github.event.release.tag_name }}" && $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "set-as-latest=true" >> $GITHUB_ENV
           fi
       - name: Update root redirect to this version
-        if: steps.check-semver.outputs.set-as-latest == 'true'
+        if: steps.check_latest.outputs.set-as-latest == 'true'
         run: |
           echo "<html>
           <head>

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "0.0.2-alpha.4",
+  "version": "0.0.2-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funidata/fudis-core",
-      "version": "0.0.2-alpha.4",
+      "version": "0.0.2-alpha.5",
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "@storybook/addon-a11y": "^8.6.12",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "0.0.2-alpha.4",
+  "version": "0.0.2-alpha.5",
   "description": "Core styles and foundations for Fudis Design System",
   "files": [
     "src",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "0.0.2-alpha.4",
+  "version": "0.0.2-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funidata/fudis-core",
-      "version": "0.0.2-alpha.4",
+      "version": "0.0.2-alpha.5",
       "dependencies": {
         "prettier-plugin-jsdoc": "^1.3.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "0.0.2-alpha.4",
+  "version": "0.0.2-alpha.5",
   "scripts": {
     "build": "docker build -t fudis-core:latest ./core && docker cp $(docker create fudis-core:latest):/usr/src/app/dist ./core/dist",
     "stylelint": "stylelint '**/*.{css,scss}'",


### PR DESCRIPTION
 https://funidata.atlassian.net/browse/DS-497
 
- Added previous tag and semver check to determine whether to run the redirect step
  - _Getting the previous tag from git command but the solution might not be robust enough (just realized a problem):_
    - _For now it would still fail (i.e. make release as latest) if we make two consecutive minor or patch releases for previous major version_ --> **Changed this based on review comment**
- Removed previously added console log of the release object (there was nothing we could work with)
- Bumped version

Couldn't find any ways for getting data from the GitHub release UI where we choose whether the release should be set as latest or not. That would be the preferable way to do the necessary check.