### PR TITLE
[Release workflow]: Adjust npm version query

### DIFF
--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -87,7 +87,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Parse library version number
-        run: echo "VERSION=$(npm pkg get version | tr -d '\"')" >> "$GITHUB_ENV"
+        run: echo "VERSION=$(npm pkg get version | jq -r '.[]')" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: npm ci
       - name: Build docs


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-506

Due to newly added npm workspaces, the version query needed a small adjustment in order for the release workflow to work again. We need to distract only the version number, e.g. _0.0.3_.
