### PR TITLE
[Documentation]: Fix Yarn link protocol

### DIFF
--- a/core/documentation/development/GettingStarted.mdx
+++ b/core/documentation/development/GettingStarted.mdx
@@ -44,11 +44,11 @@ To install project dependencies, in the **root** directory run:
 
 ## Development
 
-The development is done in the Storybook environment. Fudis Core uses the html/vite-version. You can read more about storybook from the [official Storybook site](https://storybook.js.org/).
+The development is done in the Storybook environment. Fudis Core uses the html/vite-version. You can read more about Storybook from the [official Storybook site](https://storybook.js.org/).
 
 Testing is done by Playwright, and it is used mainly for snapshot-testing.
 
-### With containers
+### With Containers
 
 Make sure Docker daemon is running, then in the **root** directory run:
 
@@ -112,11 +112,11 @@ To lint styles, in the **root** directory run:
 
 <Source code={`npm run stylelint`} />
 
-## Additional command reference
+## Additional Command Reference
 
 Here are some other commands that are useful in development.
 
-#### Build storybook
+#### Build Storybook
 
 To build the deployable version of Storybook, in the **core** directory run:
 

--- a/core/documentation/development/tooling/Symlink.mdx
+++ b/core/documentation/development/tooling/Symlink.mdx
@@ -30,5 +30,6 @@ These instructions are for Yarn v4. If you are using any other version, please c
 
 1. Navigate to **core** directory. There you have two options for creating the build.
    - **Option 1**: Command for building the library that does not rebuild the library after changes to code: `npm run build:dist`.
-   - **Option 2**: If you want to develop and test at the same time, run `npm run build:dist:watch`. This starts up Nodemon daemon that builds the dist-folder every time you make changes to any scss-files.2. Navigate to your project where you want to use the Fudis Core-package. The directory that contains the node_modules folder containing the project dependencies is the correct place to execute linking.
-2. In this project directory run `yarn add @funidata/fudis-core@portal:./{your-path-to-core-directory}/core/dist`
+   - **Option 2**: If you want to develop and test at the same time, run `npm run build:dist:watch`. This starts up Nodemon daemon that builds the dist-folder every time you make changes to any scss-files.
+2. Navigate to your project where you want to use the Fudis Core-package. The directory that contains the node_modules folder containing the project dependencies is the correct place to execute linking.
+3. In this project directory run `yarn add @funidata/fudis-core@link:./{your-path-to-core-directory}/core/dist`


### PR DESCRIPTION
- Fixed `portal:` protocol to `link:` protocol when using symlink with Yarn