### PR TITLE
[Styles]: Adjust style exports

### DIFF
--- a/core/_foundations.scss
+++ b/core/_foundations.scss
@@ -1,0 +1,23 @@
+/**
+* Foundation tokens and mixins
+*/
+@forward './src/foundations/borders/tokens';
+@forward './src/foundations/borders/mixins';
+@forward './src/foundations/breakpoints/tokens';
+@forward './src/foundations/breakpoints/mixins';
+@forward './src/foundations/colors/tokens';
+@forward './src/foundations/colors/mixins';
+@forward './src/foundations/focus/tokens';
+@forward './src/foundations/focus/mixins';
+@forward './src/foundations/grid/tokens';
+@forward './src/foundations/grid/mixins';
+@forward './src/foundations/spacing/tokens';
+@forward './src/foundations/spacing/mixins';
+@forward './src/foundations/spacing/classes';
+@forward './src/foundations/typography/tokens';
+@forward './src/foundations/typography/mixins';
+@forward './src/foundations/typography/classes';
+@forward './src/foundations/utilities/classes';
+@forward './src/foundations/utilities/mixins';
+@forward './src/foundations/z-index/tokens';
+@forward './src/foundations/z-index/mixins';

--- a/core/_index.scss
+++ b/core/_index.scss
@@ -1,52 +1,5 @@
 /**
 * Export all Core SCSS files here
 */
-
-/**
-* Assets and Foundations
-*/
-@forward './src/foundations/borders/tokens';
-@forward './src/foundations/breakpoints/tokens';
-@forward './src/foundations/colors/tokens';
-@forward './src/foundations/focus/tokens';
-@forward './src/foundations/grid/tokens';
-@forward './src/foundations/spacing/tokens';
-@forward './src/foundations/typography/tokens';
-@forward './src/foundations/z-index/tokens';
-@forward './src/foundations/borders/mixins';
-@forward './src/foundations/breakpoints/mixins';
-@forward './src/foundations/colors/mixins';
-@forward './src/foundations/focus/mixins';
-@forward './src/foundations/grid/mixins';
-@forward './src/foundations/spacing/mixins';
-@forward './src/foundations/typography/mixins';
-@forward './src/foundations/typography/classes';
-@forward './src/foundations/utilities/mixins';
-@forward './src/foundations/z-index/mixins';
-@forward './src/foundations/spacing/classes';
-@forward './src/foundations/utilities/classes';
-
-/**
-* Component styles
-*/
-@forward './src/components/alert/alert';
-@forward './src/components/button/button';
-@forward './src/components/badge/badge';
-@forward './src/components/checkbox/checkbox';
-@forward './src/components/checkbox-group/checkbox-group';
-@forward './src/components/error-summary/error-summary';
-@forward './src/components/fieldset/fieldset';
-@forward './src/components/guidance/guidance';
-@forward './src/components/horizontal-rule/horizontal-rule';
-@forward './src/components/icon/icon';
-@forward './src/components/label/label';
-@forward './src/components/link/link';
-@forward './src/components/loading-spinner/loading-spinner';
-@forward './src/components/notification/notification';
-@forward './src/components/popover/popover';
-@forward './src/components/radio-button/radio-button';
-@forward './src/components/radio-button-group/radio-button-group';
-@forward './src/components/tab-navigation/tab-navigation';
-@forward './src/components/text-area/text-area';
-@forward './src/components/text-input/text-input';
-@forward './src/components/validator-error-message/validator-error-message';
+@forward './styles';
+@forward './foundations';

--- a/core/_styles.scss
+++ b/core/_styles.scss
@@ -1,0 +1,24 @@
+/**
+* Component styles
+*/
+@forward './src/components/alert/alert';
+@forward './src/components/button/button';
+@forward './src/components/badge/badge';
+@forward './src/components/checkbox/checkbox';
+@forward './src/components/checkbox-group/checkbox-group';
+@forward './src/components/error-summary/error-summary';
+@forward './src/components/fieldset/fieldset';
+@forward './src/components/guidance/guidance';
+@forward './src/components/horizontal-rule/horizontal-rule';
+@forward './src/components/icon/icon';
+@forward './src/components/label/label';
+@forward './src/components/link/link';
+@forward './src/components/loading-spinner/loading-spinner';
+@forward './src/components/notification/notification';
+@forward './src/components/popover/popover';
+@forward './src/components/radio-button/radio-button';
+@forward './src/components/radio-button-group/radio-button-group';
+@forward './src/components/tab-navigation/tab-navigation';
+@forward './src/components/text-area/text-area';
+@forward './src/components/text-input/text-input';
+@forward './src/components/validator-error-message/validator-error-message';

--- a/core/package.json
+++ b/core/package.json
@@ -4,8 +4,21 @@
   "description": "Core styles and foundations for Fudis Design System",
   "files": [
     "src",
-    "./_index.scss"
+    "./_index.scss",
+    "./_foundations.scss",
+    "./_styles.scss"
   ],
+  "exports": {
+    "./foundations": {
+      "sass": "./_foundations.scss"
+    },
+    "./styles": {
+      "sass": "./_styles.scss"
+    },
+    ".": {
+      "sass": "./_index.scss"
+    }
+  },
   "scripts": {
     "start": "storybook dev -p 6007",
     "build:storybook": "storybook build",


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-546

Consuming application should have an opportunity to `@use` only foundation tokens and mixins, instead of importing the whole Core, including component styles.

- Separated foundations and component styles
  - `_foundations.scss`
  - `_styles.scss`
  - The already existing `_index.scss` is importing the above files and can still be used as is if necessary (but not recommended to avoid duplicate styles)
    - Not 100% sure (yet) if this will fix the whole duplicate CSS output issue but should at least be an enhancement 
      - This requires also refactoring Core imports in Ngx project
        - https://github.com/funidata/fudis/pull/625