### PR TITLE
[Grid]: Remove unnecessary mixin

### DIFF
--- a/core/src/foundations/grid/mixins.scss
+++ b/core/src/foundations/grid/mixins.scss
@@ -23,8 +23,3 @@
     @error 'Unknown grid width of #{$width}. Accepted arguments are: "xxl", "xl", "lg", "md", "sm", "xs".';
   }
 }
-
-@mixin grid-xs-margins() {
-  margin-right: spacing.$spacing-sm;
-  margin-left: spacing.$spacing-sm;
-}


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-618

- Removed the `grid-xs-margins()` mixin since it was no longer needed, and the usage was deleted from Ngx.
- Related PR in Ngx: https://github.com/funidata/fudis/pull/872
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
