### PR TITLE
[Fieldset]: Remove broken style from required class

### DIFF
--- a/core/src/components/fieldset/fieldset.scss
+++ b/core/src/components/fieldset/fieldset.scss
@@ -73,8 +73,7 @@
     &__md {
       @include typography.heading-xs;
 
-      .fudis-fieldset__legend__main__text,
-      .fudis-fieldset__legend__main__required {
+      .fudis-fieldset__legend__main__text {
         vertical-align: sub;
       }
     }


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-659

When setting Fieldset as required, the existing `vertical-align` style breaks the layout (as per in the screenshot below).
- Removed the unnecessary style from the required class

<img width="782" height="145" alt="Screenshot 2026-04-13 at 11 08 30" src="https://github.com/user-attachments/assets/01a63357-b080-4efd-aab9-14c7e3bd24a2" />

  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
