### PR TITLE
[RadioButton]: Click area is too wide

### DIFF
--- a/core/src/components/radio-button/radio-button.scss
+++ b/core/src/components/radio-button/radio-button.scss
@@ -26,13 +26,18 @@ $radio-indicator-size: calc(0.75rem / var(--fudis-rem-multiplier));
     padding-left: spacing.$spacing-xs;
   }
 
-  /* Radio button circle */
   &__content {
     display: flex;
     align-items: center;
     transform: translateX(calc(-0.1rem / var(--fudis-rem-multiplier)));
+    cursor: pointer;
     padding-left: 0;
 
+    &--disabled {
+      cursor: default;
+    }
+
+    /* Radio button circle */
     &-wrapper {
       display: flex;
       align-items: center;
@@ -88,13 +93,8 @@ $radio-indicator-size: calc(0.75rem / var(--fudis-rem-multiplier));
     left: 0;
     opacity: 0;
     margin: 0;
-    cursor: pointer;
     width: 100%;
     height: 100%;
-
-    &--disabled {
-      cursor: default;
-    }
 
     /* stylelint-disable-next-line */
     &:focus

--- a/core/src/components/radio-button/radio-button.scss
+++ b/core/src/components/radio-button/radio-button.scss
@@ -17,7 +17,7 @@ $radio-indicator-size: calc(0.75rem / var(--fudis-rem-multiplier));
   position: relative;
   align-items: center;
   margin-bottom: 0;
-  width: auto;
+  width: fit-content;
   min-height: spacing.$spacing-lg;
 
   &__label {

--- a/core/storybook-utils.js
+++ b/core/storybook-utils.js
@@ -128,6 +128,8 @@ export const createRadioButton = (
 
   const contentElement = document.createElement("div");
   contentElement.className = "fudis-radio-button__content";
+  if (disabled)
+    contentElement.classList.add("fudis-radio-button__content--disabled");
 
   const contentWrapperElement = document.createElement("div");
   contentWrapperElement.className = "fudis-radio-button__content-wrapper";
@@ -183,6 +185,8 @@ export const createCheckbox = (
 
   const checkboxContentElement = document.createElement("div");
   checkboxContentElement.className = "fudis-checkbox__content";
+  if (disabled)
+    checkboxContentElement.classList.add("fudis-checkbox__content--disabled");
 
   const checkboxContentWrapperElement = document.createElement("div");
   checkboxContentWrapperElement.className = "fudis-checkbox__content-wrapper";


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-666

This previous bug fix (https://funidata.atlassian.net/browse/DS-581, https://github.com/funidata/fudis-core/pull/122) altered the Radio Button's click area:
- It became the whole width of the label element
- Wanted click area is only the radio input and its visible label

Other:
- `--disabled` state CSS classes were missing from the HTML example in both RadioButton and Checkbox
- `cursor: pointer` was not working properly due to its placement in the elements hierarchy
  - Necessary CSS class addition for default cursor in disabled Radio Button is done in Ngx (https://github.com/funidata/fudis/pull/905)
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
