### PR TITLE
[Documentation]: Update development docs

### DIFF
--- a/core/documentation/development/GettingStarted.mdx
+++ b/core/documentation/development/GettingStarted.mdx
@@ -55,6 +55,12 @@ Make sure Docker daemon is running, then in the **root** directory run:
 
 The First startup takes a while as Docker fetches and builds the necessary image. Once complete, Storybook is accessible at [http://localhost:6007](http://localhost:6007).
 
+Once you are done, shut down the development environment with:
+
+<Source code={`npm stop`} />
+
+You can use `docker ps` to verify all containers are down (and to check their status if something is not working).
+
 #### Testing
 
 To run all tests, run the next command in the **root** directory:

--- a/core/documentation/development/GettingStarted.mdx
+++ b/core/documentation/development/GettingStarted.mdx
@@ -31,7 +31,7 @@ Setting up your local development environment according to these instructions is
 
 Clone the upstream repository to your machine:
 
-<Source code={`git@github.com:funidata/fudis-core.git`} />
+<Source code={`git clone git@github.com:funidata/fudis-core.git`} />
 
 If you do not have write access and are not working for Funidata, you need to first fork our repository to your own account and use that for development.
 


### PR DESCRIPTION
DS-660

Updated the development docs to include full command for cloning the github repo and mention about how to stop Docker container. The latter was copied from Fudis docs for consistency.
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
