### PR TITLE
[Documentation]: Add VS Code documentation

### DIFF
--- a/core/.storybook/preview.js
+++ b/core/.storybook/preview.js
@@ -43,9 +43,10 @@ const preview = {
               "How to Contribute",
               "Tooling",
               [
+                "Setup VS Code",
+                "Testing Local Changes in Application",
                 "Git and GitHub Conventions",
                 "Releases",
-                "Testing Local Changes in Application",
               ],
               "Practises",
               [

--- a/core/documentation/development/tooling/SetupVSCode.mdx
+++ b/core/documentation/development/tooling/SetupVSCode.mdx
@@ -24,15 +24,12 @@ Recommended extensions are listed in `settings/.vscode/extensions.json`. If you 
 
 These linting and formatting extensions are necessary to interactively see linting errors and auto-format files:
 
-- [ESLint (`dbaeumer.vscode-eslint`)](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [Prettier - Code formatter (`esbenp.prettier-vscode`)](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 - [Stylelint (`stylelint.vscode-stylelint`)](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
 
 ### Recommended Extensions
 
 The rest of the extensions in `extensions.json` are recommended for a better developer experience. Use them according to taste.
-
-We also recommend that you remove the common `rvest.vs-code-prettier-eslint` extension as it has been deprecated by `dbaeumer.vscode-eslint` listed above and can cause confusion.
 
 ## Settings
 

--- a/core/documentation/development/tooling/SetupVSCode.mdx
+++ b/core/documentation/development/tooling/SetupVSCode.mdx
@@ -12,7 +12,7 @@ Copy VS Code configuration files (run in repository root):
 
 <Source code={`cp -R settings/.vscode .`} />
 
-VS Code will use this configuration only when you open it under Fudis repository, leaving your global configuration unaffected.
+VS Code will use this configuration only when you open it under Core repository, leaving your global configuration unaffected.
 
 After copying the files, reload VS Code (on Mac: CMD+Shift+P > "Developer: Reload Window").
 

--- a/core/documentation/development/tooling/SetupVSCode.mdx
+++ b/core/documentation/development/tooling/SetupVSCode.mdx
@@ -1,0 +1,41 @@
+import { Meta, Source } from "@storybook/addon-docs/blocks";
+
+<Meta title="Documentation/Development/Tooling/Setup VS Code" />
+
+# Visual Studio Code Setup
+
+As per the title, these instructions are written for Microsoft Visual Studio Code. The setup described here ensures a smooth and uniform developer experience along with consistent code. If you deviate from this setup, please make sure you understand the goals of our common workflow and how your setup achieves them. Using this setup as a basis of your own is highly recommended.
+
+## Using Recommended Setup
+
+Copy VS Code configuration files (run in repository root):
+
+<Source code={`cp -R settings/.vscode .`} />
+
+VS Code will use this configuration only when you open it under Fudis repository, leaving your global configuration unaffected.
+
+After copying the files, reload VS Code (on Mac: CMD+Shift+P > "Developer: Reload Window").
+
+## Extensions
+
+Recommended extensions are listed in `settings/.vscode/extensions.json`. If you copied over that file as recommended and reloaded VS Code, you should see the recommended listed in the Extensions tab and can easily inspect and install them (note that VS Code lists only the extensions that you do not have).
+
+### Required Extensions
+
+These linting and formatting extensions are necessary to interactively see linting errors and auto-format files:
+
+- [ESLint (`dbaeumer.vscode-eslint`)](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+- [Prettier - Code formatter (`esbenp.prettier-vscode`)](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+- [Stylelint (`stylelint.vscode-stylelint`)](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
+
+### Recommended Extensions
+
+The rest of the extensions in `extensions.json` are recommended for a better developer experience. Use them according to taste.
+
+We also recommend that you remove the common `rvest.vs-code-prettier-eslint` extension as it has been deprecated by `dbaeumer.vscode-eslint` listed above and can cause confusion.
+
+## Settings
+
+Recommended settings are specified in `settings/.vscode/settings.json`. They assume that at least the [required extensions](#required-extensions) are installed.
+
+Take a look at the file to see all recommendations and commentary about them. Remember that VS Code applies `.vscode/settings.json` contents only to that folder and its subfolders, so your global configuration will not be affected by using these recommendations.

--- a/settings/.vscode/extensions.json
+++ b/settings/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "stylelint.vscode-stylelint",
     "formulahendry.auto-rename-tag",


### PR DESCRIPTION
DS-545

Copied the VS Code documentation from Fudis to here. I removed the table about the most important VS Code settings, since the Fudis Core project doesn't specify a working directory, unlike Fudis, so it seemed unnecessary to have the table just for "formatOnSave".
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
