### PR TITLE
[GithubActions]: Update versions which run on Node 24

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -11,15 +11,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./
           tags: fudis-core
           outputs: type=docker,dest=/tmp/fudis-core.image.tar
       - name: Save image as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fudis-core
           path: /tmp/fudis-core.image.tar

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -28,9 +28,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fudis-core
           path: /tmp
@@ -48,9 +48,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fudis-core
           path: /tmp
@@ -68,9 +68,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fudis-core
           path: /tmp
@@ -93,13 +93,13 @@ jobs:
             --mount type=bind,source=./tests/test-results,target=/usr/src/app/test-results \
             --mount type=bind,source=./tests/playwright-report,target=/usr/src/app/playwright-report \
             fudis-core-pw
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report
           path: tests/playwright-report/
           retention-days: 7
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: test-results


### PR DESCRIPTION
DS-660

- Updated GitHub Actions to versions that run on Node 24
  - This should surpress the warnings from actions: _"Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: ..."_.
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
