### PR TITLE
chore: Update @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "tests"
       ],
       "dependencies": {
-        "@types/node": "^25.3.3",
+        "@types/node": "^25.9.1",
         "prettier-plugin-jsdoc": "^1.8.0"
       },
       "devDependencies": {
@@ -2783,10 +2783,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.3",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/unist": {
@@ -5688,7 +5690,9 @@
       "license": "0BSD"
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -5830,7 +5834,7 @@
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@types/node": "^25.3.3"
+        "@types/node": "^25.9.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "stylelint-config-standard-scss": "^17.0.0"
   },
   "dependencies": {
-    "@types/node": "^25.3.3",
+    "@types/node": "^25.9.1",
     "prettier-plugin-jsdoc": "^1.8.0"
   }
 }

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -11,7 +11,7 @@
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@types/node": "^25.3.3"
+        "@types/node": "^25.9.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -31,13 +31,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
-      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/fsevents": {
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     }

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,6 +12,6 @@
   "description": "Tests for Fudis Core",
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@types/node": "^25.3.3"
+    "@types/node": "^25.9.1"
   }
 }


### PR DESCRIPTION
DS-661

Updated the `@types/node` package version manually after spotting it in PR #180 . Since the Dependabot PR is failing, I figured it's best to do the updates one by one.
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
