### PR TITLE
[Dependencies]: Remove Playwright update from root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4801,13 +4801,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.58.2",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4820,9 +4818,7 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.58.2",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4830,10 +4830,7 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2368,13 +2368,11 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.58.2",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "prettier-plugin-jsdoc": "^1.8.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.60.0",
         "prettier": "^3.8.3",
         "stylelint": "^17.11.0",
         "stylelint-config-concentric-order": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "postversion": "git commit --amend -m \"Bump to version v$npm_package_version\""
   },
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
     "prettier": "^3.8.3",
     "stylelint": "^17.11.0",
     "stylelint-config-concentric-order": "^5.5.0",


### PR DESCRIPTION
DS-662

Playwright was accidentally updated in the root, which is not where it is supposed to be. We decided to postpone the Playwright update for later, so this revert is done in a separate PR.
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
