### PR TITLE
Bump to version v3.1.1

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funidata/fudis-core",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "@storybook/addon-a11y": "10.4.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Core styles and foundations for Fudis Design System",
   "files": [
     "src",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funidata/fudis-core",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "workspaces": [
         "core",
         "tests"
@@ -24,7 +24,7 @@
     },
     "core": {
       "name": "@funidata/fudis-core",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "@storybook/addon-a11y": "10.4.0",
@@ -6601,7 +6601,7 @@
       }
     },
     "tests": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funidata/fudis-core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": "true",
   "workspaces": [
     "core",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tests",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tests",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": "true",
   "scripts": {
     "test": "npx playwright test",


### PR DESCRIPTION
DS-662

Patch version which includes removing `optionalDependencies` from the shipped npm package.
  
