### PR TITLE
[Checkbox]: Remove icon color style

### DIFF
--- a/core/src/components/checkbox/checkbox.scss
+++ b/core/src/components/checkbox/checkbox.scss
@@ -62,10 +62,6 @@
       width: spacing.$checkbox-size;
       height: spacing.$checkbox-size;
 
-      &__icon .fudis-icon {
-        fill: colors.$color-gray-middle;
-      }
-
       &--focused {
         @include focus.focus-checkbox;
       }


### PR DESCRIPTION
DS-662

- Removed selected checkbox's icon color style
  - For some reason this style did not affect our Storybook examples but it rendered the wrong color (gray-middle #727272) in consuming app when it should've been the color given to the icon component or its default color (gray-dark #484848).
  - Not sure if this has been intentional but I couldn't figure out why we would ever want to give the middle (lighter) color to the selected checkbox.
  - In the end, I didn't see the need for this class hence the deletion and not only the color change.
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
