### PR TITLE
[GithubActions]: Update aws-actions

### DIFF
--- a/.github/workflows/delete_branch_docs.yaml
+++ b/.github/workflows/delete_branch_docs.yaml
@@ -14,7 +14,7 @@ jobs:
       deployments: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/delete_landing_page_from_pr.yaml
+++ b/.github/workflows/delete_landing_page_from_pr.yaml
@@ -14,7 +14,7 @@ jobs:
       deployments: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish_docs_from_pr.yaml
+++ b/.github/workflows/publish_docs_from_pr.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish_landing_page.yaml
+++ b/.github/workflows/publish_landing_page.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish_landing_page_from_pr.yaml
+++ b/.github/workflows/publish_landing_page_from_pr.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release_new_version.yaml
+++ b/.github/workflows/release_new_version.yaml
@@ -82,7 +82,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
DS-662

- Updated `aws-actions/configure-aws-credentials` from `v4` to `v6`
  - `v6` is running on Node.js 24 which will be forced by default starting from June 16th, 2026.
- There is still one more action running on Node.js 20 which is `bobheadxi/deployments` but unfortunately it has yet been updated. There is open issue and PR about it in their repository.
  - This action is responsible for the branch deployment on each opened PR
  - I assume it is not crucial for our workflow so I didn't look up for alternatives yet. Could be worth to check if the same functionality can be implemented in a more "native" way, without third party action.
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
