### PR TITLE
[GithubActions]: Update publish and delete documentation deployment workflows

### DIFF
--- a/.github/workflows/delete_branch_docs.yaml
+++ b/.github/workflows/delete_branch_docs.yaml
@@ -1,6 +1,7 @@
 name: Delete branch Storybook documentation
 
-on: delete
+on:
+  delete:
 
 jobs:
   delete-docs:
@@ -10,6 +11,9 @@ jobs:
     permissions:
       contents: read
       deployments: write
+    env:
+      BRANCH_REF: ${{ github.event.ref }}
+      ENV_NAME: Storybook documentation for branch ${{ github.event.ref }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -18,10 +22,33 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Delete Storybook docs from S3 bucket
-        run: aws s3 rm s3://${{ vars.AWS_S3_BUCKET_NAME }}/core/branch/${{ github.event.ref }} --recursive
+        run: aws s3 rm s3://${{ vars.AWS_S3_BUCKET_NAME }}/core/branch/${{ env.BRANCH_REF }} --recursive
       - name: Deactivate Storybook deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
+        if: always()
+        uses: actions/github-script@v8
         with:
-          step: deactivate-env
-          env: Storybook documentation for branch ${{ github.event.ref }}
-          desc: Environment was pruned
+          script: |
+            const environment = process.env.ENV_NAME;
+
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment,
+              per_page: 100
+            });
+
+            if (deployments.length === 0) {
+              core.info(`No deployments found for "${environment}"`);
+              return;
+            }
+
+            for (const deployment of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: "inactive",
+                environment,
+                description: "Environment was pruned"
+              });
+            }

--- a/.github/workflows/delete_branch_docs.yaml
+++ b/.github/workflows/delete_branch_docs.yaml
@@ -1,8 +1,5 @@
 name: Delete branch Storybook documentation
 
-permissions:
-  contents: read
-  deployments: write
 on: delete
 
 jobs:
@@ -11,6 +8,7 @@ jobs:
     if: github.event.ref_type == 'branch'
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       deployments: write
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/delete_landing_page_from_pr.yaml
+++ b/.github/workflows/delete_landing_page_from_pr.yaml
@@ -1,6 +1,7 @@
 name: Delete branch landing page
 
-on: delete
+on:
+  delete:
 
 jobs:
   delete-landing-page-deployment:
@@ -10,6 +11,9 @@ jobs:
     permissions:
       contents: read
       deployments: write
+    env:
+      BRANCH_REF: ${{ github.event.ref }}
+      ENV_NAME: Landing page for branch ${{ github.event.ref }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -18,10 +22,33 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Delete landing page from S3 bucket
-        run: aws s3 rm s3://${{ vars.AWS_S3_BUCKET_NAME }}/landing-page/branch/${{ github.event.ref }} --recursive
+        run: aws s3 rm s3://${{ vars.AWS_S3_BUCKET_NAME }}/landing-page/branch/${{ env.BRANCH_REF }} --recursive
       - name: Deactivate landing page deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
+        if: always()
+        uses: actions/github-script@v8
         with:
-          step: deactivate-env
-          env: Landing page for branch ${{ github.event.ref }}
-          desc: Environment was pruned
+          script: |
+            const environment = process.env.ENV_NAME;
+
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment,
+              per_page: 100
+            });
+
+            if (deployments.length === 0) {
+              core.info(`No deployments found for "${environment}"`);
+              return;
+            }
+
+            for (const deployment of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: "inactive",
+                environment,
+                description: "Environment was pruned"
+              });
+            }

--- a/.github/workflows/delete_landing_page_from_pr.yaml
+++ b/.github/workflows/delete_landing_page_from_pr.yaml
@@ -1,8 +1,5 @@
 name: Delete branch landing page
 
-permissions:
-  contents: read
-  deployments: write
 on: delete
 
 jobs:
@@ -11,6 +8,7 @@ jobs:
     if: github.event.ref_type == 'branch'
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       deployments: write
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/publish_docs_from_pr.yaml
+++ b/.github/workflows/publish_docs_from_pr.yaml
@@ -1,8 +1,5 @@
 name: Publish Storybook documentation from PR
 
-permissions:
-  contents: read
-  deployments: write
 on:
   # Must be run for pushes to associate deployment with PR. Otherwise docs link is not shown.
   push:
@@ -17,6 +14,9 @@ jobs:
   publish:
     name: Publish PR Storybook docs to AWS
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      deployments: write
     defaults:
       run:
         working-directory: core

--- a/.github/workflows/publish_docs_from_pr.yaml
+++ b/.github/workflows/publish_docs_from_pr.yaml
@@ -22,11 +22,26 @@ jobs:
         working-directory: core
     steps:
       - name: Start Storybook deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
         id: deployment
+        uses: actions/github-script@v8
         with:
-          step: start
-          env: Storybook documentation for branch ${{ github.ref_name }}
+          script: |
+            const envName = `Storybook documentation for branch ${context.ref.replace('refs/heads/', '')}`;
+
+            const { data } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: envName,
+              description: `Storybook docs deploy for ${context.ref}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false
+            });
+
+            core.setOutput('deployment_id', String(data.id));
+            core.setOutput('environment', envName);
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Node.js
@@ -46,11 +61,26 @@ jobs:
       - name: Copy storybook docs to S3 bucket
         run: aws s3 sync storybook-static s3://${{ vars.AWS_S3_BUCKET_NAME }}/core/branch/${{ github.ref_name }} --delete --cache-control max-age=5
       - name: Finish deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
-        if: always()
+        if: always() && steps.deployment.outputs.deployment_id
+        uses: actions/github-script@v8
+        env:
+          JOB_STATUS: ${{ job.status }}
         with:
-          step: finish
-          status: ${{ job.status }}
-          env: ${{ steps.deployment.outputs.env }}
-          env_url: https://fudis.funidata.fi/core/branch/${{ github.ref_name }}/index.html
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          script: |
+            const map = {
+              success: 'success',
+              failure: 'failure',
+              cancelled: 'error'
+            };
+            const state = map[process.env.JOB_STATUS] ?? 'error';
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number('${{ steps.deployment.outputs.deployment_id }}'),
+              state,
+              environment: '${{ steps.deployment.outputs.environment }}',
+              environment_url: 'https://fudis.funidata.fi/core/branch/${{ github.ref_name }}/index.html',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: `Storybook documentation deployment finished with ${process.env.JOB_STATUS}`
+            });

--- a/.github/workflows/publish_landing_page_from_pr.yaml
+++ b/.github/workflows/publish_landing_page_from_pr.yaml
@@ -17,11 +17,26 @@ jobs:
       deployments: write
     steps:
       - name: Start landing page deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
         id: deployment
+        uses: actions/github-script@v8
         with:
-          step: start
-          env: Landing page for branch ${{ github.ref_name }}
+          script: |
+            const envName = `Landing page for branch ${context.ref.replace('refs/heads/', '')}`;
+
+            const { data } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: envName,
+              description: `Landing page deploy for ${context.ref}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false
+            });
+
+            core.setOutput('deployment_id', String(data.id));
+            core.setOutput('environment', envName);
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Configure AWS credentials
@@ -33,11 +48,26 @@ jobs:
       - name: Copy landing page to S3 bucket
         run: aws s3 sync landing-page s3://${{ vars.AWS_S3_BUCKET_NAME }}/landing-page/branch/${{ github.ref_name }} --delete --cache-control max-age=5
       - name: Finish landing page deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
-        if: always()
+        if: always() && steps.deployment.outputs.deployment_id
+        uses: actions/github-script@v8
+        env:
+          JOB_STATUS: ${{ job.status }}
         with:
-          step: finish
-          status: ${{ job.status }}
-          env: ${{ steps.deployment.outputs.env }}
-          env_url: https://fudis.funidata.fi/landing-page/branch/${{ github.ref_name }}/index.html
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          script: |
+            const map = {
+              success: 'success',
+              failure: 'failure',
+              cancelled: 'error'
+            };
+            const state = map[process.env.JOB_STATUS] ?? 'error';
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number('${{ steps.deployment.outputs.deployment_id }}'),
+              state,
+              environment: '${{ steps.deployment.outputs.environment }}',
+              environment_url: 'https://fudis.funidata.fi/landing-page/branch/${{ github.ref_name }}/index.html',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: `Landing page deployment finished with ${process.env.JOB_STATUS}`
+            });

--- a/.github/workflows/publish_landing_page_from_pr.yaml
+++ b/.github/workflows/publish_landing_page_from_pr.yaml
@@ -1,8 +1,5 @@
 name: Publish landing page from PR
 
-permissions:
-  contents: read
-  deployments: write
 on:
   push:
     paths:
@@ -15,6 +12,9 @@ jobs:
   publish:
     name: Publish PR landing page to AWS
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - name: Start landing page deployment
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8


### PR DESCRIPTION
DS-662

Same refactoring for publish and delete documentation (i.e. Storybook and landing page) deployment workflows as in [this Ngx PR](https://github.com/funidata/fudis/pull/941), from where you can find more details about the changes in the PR description.
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
