### PR TITLE
[Chore]: Add moldoc to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the Fudis Core repo. They will be requested for review 
 # when someone opens a pull request.
-*     @RiinaKuu @MayaMarjut @mfaarni @krisrelax @emilyhernandez
+*     @RiinaKuu @MayaMarjut @mfaarni @krisrelax @emilyhernandez @moldoc


### PR DESCRIPTION
DS-681 --> https://funidata.atlassian.net/browse/DS-689

- Added **moldoc** temporarily to CODEOWNERS for the summer period
- They have also been added to _Collaborators and teams_ as admin
  - I didn't have permissions to modify the **fudis** team, so had to add separately
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
