### PR TITLE
[chore]: Remove moldoc from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the Fudis Core repo. They will be requested for review 
 # when someone opens a pull request.
-*     @RiinaKuu @MayaMarjut @mfaarni @krisrelax @emilyhernandez @moldoc
+*     @RiinaKuu @MayaMarjut @mfaarni @krisrelax @emilyhernandez


### PR DESCRIPTION
DS-685

- Removed moldoc from codeowners and revoked their admin rights from Github _Collaborators and teams_.
  
### Developer's checklist
- [ ] I updated Storybook stories and HTML examples according to latest changes
- [ ] I included visual regression tests for new UI design and different style variations
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
