### PR TITLE
[GithubActions]: Add missing permissions definitions

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -3,6 +3,9 @@ name: Build project
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build-image:
     name: Build and save project image

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -14,6 +14,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build image


### PR DESCRIPTION
DS-685

Add missing permissions rules in GitHub actions. This should fix the code scanning issues the "Security and quality" tab.
